### PR TITLE
Make `build list` support table output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/SurveyMonkey/teamcity_cli',
     py_modules=['teamcitycli'],
     zip_safe=False,
-    install_requires=['click', 'pyteamcity'],
+    install_requires=['click', 'pyteamcity', 'terminaltables'],
     entry_points = """\
       [console_scripts]
       teamcity_cli = teamcitycli:cli

--- a/teamcitycli.py
+++ b/teamcitycli.py
@@ -6,6 +6,7 @@ import click
 import pygments.formatters
 import pygments.lexers
 from pyteamcity import TeamCity
+from terminaltables import AsciiTable
 
 
 lexer = pygments.lexers.get_lexer_by_name('json')
@@ -79,11 +80,24 @@ def project_show(ctx, args):
 @build.command(name='list')
 @click.option('--start', default=0, help='Start index')
 @click.option('--count', default=100, help='Max number of items to show')
+@click.option('--output-format', default='table',
+              type=click.Choice(['table', 'json']),
+              help='Output format')
 @click.pass_context
-def build_list(ctx, start, count):
+def build_list(ctx, start, count, output_format):
     """Display list of builds"""
     data = ctx.obj.get_all_builds(start=start, count=count)
-    output_json_data(data)
+    if output_format == 'table':
+        column_names = ['status', 'number', 'buildTypeId', 'branchName']
+        table_data = [column_names]
+        for build in data['build']:
+            row = [build.get(column_name, 'N/A')
+                   for column_name in column_names]
+            table_data.append(row)
+        table = AsciiTable(table_data)
+        click.echo(table.table)
+    elif output_format == 'json':
+        output_json_data(data)
 
 
 @build.group(name='show')


### PR DESCRIPTION
Default `--output-format` is `table`. It can also be set to `json`.

```
[marca@marca-mac2 teamcity_cli]$ teamcity_cli build list --count=8
+---------+---------------+----------------------------------------+------------+
| status  | number        | buildTypeId                            | branchName |
+---------+---------------+----------------------------------------+------------+
| SUCCESS | 57            | Teampretty_ReleaseToMt1_Deploy         | master     |
| SUCCESS | 2015.02.25.62 | Teampretty_Branches_Package            | master     |
| SUCCESS | 65            | Teampretty_Branches_Py27               | master     |
| SUCCESS | 7             | SmlibExpr_Branches_Pyjscov             | master     |
| FAILURE | 1             | Trackingsvc_Branches_Py27              | develop    |
| FAILURE | 1             | Trackingsvc_Branches_Py26              | develop    |
| SUCCESS | 10            | SmlibExpr_PullRequests_PyjscovCoverage | master     |
| SUCCESS | 9             | SmlibExpr_PullRequests_Pyjscov         | master     |
+---------+---------------+----------------------------------------+------------+
```

Cc: @aconrad, @sudarkoff 