### PR TITLE
Add --build-type-id option to `build list`

### DIFF
--- a/teamcitycli.py
+++ b/teamcitycli.py
@@ -80,13 +80,19 @@ def project_show(ctx, args):
 @build.command(name='list')
 @click.option('--start', default=0, help='Start index')
 @click.option('--count', default=100, help='Max number of items to show')
+@click.option('--build-type-id', default=None, help='buildTypeId to filter on')
 @click.option('--output-format', default='table',
               type=click.Choice(['table', 'json']),
               help='Output format')
 @click.pass_context
-def build_list(ctx, start, count, output_format):
+def build_list(ctx, start, count, build_type_id, output_format):
     """Display list of builds"""
-    data = ctx.obj.get_all_builds(start=start, count=count)
+    if build_type_id:
+        data = ctx.obj.get_all_builds_by_build_type_id(
+            start=start, count=count, build_type_id=build_type_id)
+    else:
+        data = ctx.obj.get_all_builds(start=start, count=count)
+
     if output_format == 'table':
         column_names = ['status', 'number', 'buildTypeId', 'branchName']
         table_data = [column_names]


### PR DESCRIPTION
Allow `build list` command to filter using `--build-type-id`.

E.g.:

```
[marca@marca-mac2 teamcity_cli]$ teamcity_cli build list --count=8 --build-type-id=Teampretty_Branches_Py27
+---------+--------+--------------------------+------------+
| status  | number | buildTypeId              | branchName |
+---------+--------+--------------------------+------------+
| SUCCESS | 65     | Teampretty_Branches_Py27 | master     |
| SUCCESS | 64     | Teampretty_Branches_Py27 | master     |
| SUCCESS | 62     | Teampretty_Branches_Py27 | master     |
| SUCCESS | 61     | Teampretty_Branches_Py27 | master     |
| SUCCESS | 60     | Teampretty_Branches_Py27 | master     |
| SUCCESS | 59     | Teampretty_Branches_Py27 | master     |
| SUCCESS | 58     | Teampretty_Branches_Py27 | master     |
| SUCCESS | 57     | Teampretty_Branches_Py27 | master     |
+---------+--------+--------------------------+------------+
```

Cc: @aconrad, @sudarkoff 