### PR TITLE
Colorize SUCCESS & FAILURE in `build list` output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/SurveyMonkey/teamcity_cli',
     py_modules=['teamcitycli'],
     zip_safe=False,
-    install_requires=['click', 'pyteamcity', 'terminaltables'],
+    install_requires=['click', 'colorclass', 'pyteamcity', 'terminaltables'],
     entry_points="""\
       [console_scripts]
       teamcity_cli = teamcitycli:cli

--- a/teamcitycli.py
+++ b/teamcitycli.py
@@ -3,6 +3,7 @@
 import json
 
 import click
+from colorclass import Color
 import pygments.formatters
 import pygments.lexers
 from pyteamcity import TeamCity
@@ -134,9 +135,23 @@ def output_table(column_names, data):
     for build in data['build']:
         row = [build.get(column_name, 'N/A')
                for column_name in column_names]
+        colorize_row(row)
         table_data.append(row)
     table = AsciiTable(table_data)
     click.echo(table.table)
+
+
+def colorize_row(row):
+    for idx, value in enumerate(row):
+        if value == 'SUCCESS':
+            row[idx] = colorize(value, 'green')
+        elif value == 'FAILURE':
+            row[idx] = colorize(value, 'red')
+
+
+def colorize(s, color, auto=True):
+    tag = '%s%s' % ('auto' if auto else '', color)
+    return Color('{%s}%s{/%s}' % (tag, s, tag))
 
 
 @build.group(name='show')


### PR DESCRIPTION
In `build list` output, colorize `SUCCESS` as green and `FAILURE` as red, using [colorclass](https://github.com/Robpol86/colorclass) module.

![screen shot 2015-02-27 at 10 13 20 am](https://cloud.githubusercontent.com/assets/305268/6418346/526de0ba-be69-11e4-821b-b90b70cbb7e0.png)
