### PR TITLE
Use terminaltables.SingleTable

### DIFF
--- a/teamcitycli.py
+++ b/teamcitycli.py
@@ -7,7 +7,7 @@ from colorclass import Color
 import pygments.formatters
 import pygments.lexers
 from pyteamcity import TeamCity
-from terminaltables import AsciiTable
+import terminaltables
 
 
 lexer = pygments.lexers.get_lexer_by_name('json')
@@ -137,7 +137,7 @@ def output_table(column_names, data):
                for column_name in column_names]
         colorize_row(row)
         table_data.append(row)
-    table = AsciiTable(table_data)
+    table = terminaltables.SingleTable(table_data)
     click.echo(table.table)
 
 


### PR DESCRIPTION
instead of `terminaltables.AsciiTable`.

This makes it use fancy line-drawing characters instead of ASCII characters like `-` and `+`.

![screen shot 2015-02-28 at 9 59 01 am](https://cloud.githubusercontent.com/assets/305268/6427251/94b72bee-bf30-11e4-92a5-75bb3e20ece0.png)
